### PR TITLE
Improve/skill review optimization

### DIFF
--- a/.github/workflows/skill-review.yml
+++ b/.github/workflows/skill-review.yml
@@ -1,0 +1,13 @@
+name: Skill Review
+on:
+  pull_request:
+    paths: ['**/SKILL.md']
+jobs:
+  review:
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+      contents: read
+    steps:
+      - uses: actions/checkout@v4
+      - uses: tesslio/skill-review@22e928dd837202b2b1d1397e0114c92e0fae5ead # main

--- a/skills/github-committer/SKILL.md
+++ b/skills/github-committer/SKILL.md
@@ -1,15 +1,7 @@
 ---
 name: github-committer
-description: >
-  Commits Terraform module files to GitHub using GitHub MCP server tools.
-  Handles both new file creation and existing file updates with SHA tracking.
-  Supports batch commits for multiple files. Use when committing generated or
-  updated Terraform modules to a GitHub repository after HITL approval. Never
-  uses shell git commands — exclusively uses MCP tools for all GitHub operations.
-compatibility: >
-  Requires GitHub MCP server connection with tools: create_or_update_file,
-  get_file_contents, list_directory_contents. Requires prior HITL approval
-  before any commit operation.
+description: "Commits Terraform module files to GitHub using GitHub MCP server tools. Handles both new file creation and existing file updates with SHA tracking. Supports batch commits for multiple files. Use when committing generated or updated Terraform modules to a GitHub repository after HITL approval. Never uses shell git commands — exclusively uses MCP tools for all GitHub operations."
+compatibility: "Requires GitHub MCP server connection with tools: create_or_update_file, get_file_contents, list_directory_contents. Requires prior HITL approval before any commit operation."
 metadata:
   author: talkops-ai
   version: "1.0"
@@ -19,12 +11,7 @@ allowed-tools: read_file ls
 
 # GitHub Committer
 
-## Overview
-
-You commit Terraform module files to GitHub using GitHub MCP server tools
-exclusively. You never use shell `git` commands. You handle both creating new
-files and updating existing files with proper SHA tracking for conflict
-prevention.
+Commits Terraform module files to GitHub via MCP server tools exclusively. Handles new file creation and existing file updates with SHA tracking for conflict prevention.
 
 ## Workflow
 
@@ -37,27 +24,21 @@ Progress:
 
 ### 1. Verify HITL Approval
 
-Before ANY commit operation, verify that HITL (Human-in-the-Loop) approval
-has been granted. This is a hard requirement — committing without approval is
-a violation of the workflow rules.
+Before ANY commit, verify HITL approval has been granted — committing without approval is a hard workflow violation.
 
-**Repository and branch** are provided dynamically by the coordinator in the
-task description (e.g., `"Commit vpc module to acme/infra-terraform branch main"`).
-These come from the user via the `request_commit_approval` HITL gate — do NOT
-fall back to environment variables. If the task description does not contain a
-repository and branch, STOP and report:
+**Repository and branch** are provided dynamically by the coordinator in the task description (e.g., `"Commit vpc module to acme/infra-terraform branch main"`). These come from the user via `request_commit_approval` — do NOT fall back to environment variables.
+
+If the task description does not contain repository and branch, STOP:
 ```
 Cannot commit: repository and branch not specified. The coordinator must provide these via request_commit_approval.
 ```
 
-If no approval is present in the conversation history, STOP and report:
+If no approval is present in the conversation history, STOP:
 ```
 Cannot commit: HITL approval not found. The coordinator must request approval first.
 ```
 
 ### 2. List Files to Commit
-
-Read the module directory to get the complete list of files:
 
 ```
 ls /workspace/terraform_modules/{service}/
@@ -67,24 +48,17 @@ Every `.tf` file and `README.md` in the directory should be committed.
 
 ### 3. Determine New vs. Existing Files
 
-**For NEW files** (first-time module commit):
-- Use `create_or_update_file` directly
-- Do NOT call `get_file_contents` first — the file won't exist in the repo yet
-- Attempting to get SHA for a non-existent file will cause an error
+**NEW files**: Use `create_or_update_file` directly — do NOT call `get_file_contents` first (it will 404).
 
-**For EXISTING files** (module update commit):
-- Call `get_file_contents(repo, path)` to get the current SHA
-- Pass the SHA to `create_or_update_file` to prevent conflicts
-- If `get_file_contents` returns a 404 error, treat it as a new file (skip SHA)
+**EXISTING files**: Call `get_file_contents(repo, path)` to get the current SHA, then pass it to `create_or_update_file`. If `get_file_contents` returns 404, treat as new (skip SHA).
 
-See [references/mcp-tool-reference.md](references/mcp-tool-reference.md) for
-detailed tool signatures.
+See [references/mcp-tool-reference.md](references/mcp-tool-reference.md) for detailed tool signatures.
 
 ### 4. Commit All Files
 
 For each file in the module:
 
-1. Read the file content from the virtual filesystem:
+1. Read from the virtual filesystem:
    ```
    read_file /workspace/terraform_modules/{service}/{filename}
    ```
@@ -115,12 +89,7 @@ Committed {N} files. Commit URL: https://github.com/{repo}/commit/{sha}
 
 ## Gotchas
 
-- **Never use shell `git` commands** — always use MCP tools
-- **Never commit without HITL approval** — this is a hard workflow rule
-- For NEW files, do NOT call `get_file_contents` first — it will 404
-- For EXISTING files, ALWAYS get the SHA first — committing without SHA will
-  fail if the file was modified since last fetch
-- If `get_file_contents` errors with 404, the file is new — proceed without SHA
-- Content must be base64-encoded for the GitHub API — the MCP tool handles
-  this automatically
+- Never use shell `git` commands — always use MCP tools
+- Never commit without HITL approval
+- NEW files: skip `get_file_contents` (it will 404). EXISTING files: always get SHA first
 - Batch all files in a logical commit group — don't create N separate commits

--- a/skills/tf-module-generator/SKILL.md
+++ b/skills/tf-module-generator/SKILL.md
@@ -1,15 +1,7 @@
 ---
 name: tf-module-generator
-description: >
-  Generates complete, production-ready Terraform .tf files for any AWS module.
-  Follows loaded service-specific skills for HCL patterns, variable schemas,
-  and output schemas. Use when asked to create a new Terraform module, generate
-  infrastructure code, write HCL for any AWS service, or produce .tf files.
-  Works with any AWS service that has hashicorp/aws Terraform provider support.
-compatibility: >
-  Requires write_file, read_file, edit_file, ls, and grep tools.
-  Designed for LangChain Deep Agents with virtual filesystem backend.
-  Terraform >= 1.5 and hashicorp/aws provider >= 5.0.
+description: "Generates complete, production-ready Terraform .tf files for any AWS module. Follows loaded service-specific skills for HCL patterns, variable schemas, and output schemas. Use when asked to create a new Terraform module, generate infrastructure code, write HCL for any AWS service, or produce .tf files. Works with any AWS service that has hashicorp/aws Terraform provider support."
+compatibility: "Requires write_file, read_file, edit_file, ls, and grep tools. Designed for LangChain Deep Agents with virtual filesystem backend. Terraform >= 1.5 and hashicorp/aws provider >= 5.0."
 metadata:
   author: talkops-ai
   version: "1.0"
@@ -19,12 +11,7 @@ allowed-tools: write_file read_file edit_file ls grep
 
 # Terraform Module Generator
 
-## Overview
-
-You write complete, production-ready Terraform files for AWS modules. Your
-service-specific skill (e.g., `{service}-module-generator/SKILL.md`) is loaded
-automatically and contains the exact resources, variables, and outputs to
-generate. This skill provides your general workflow and mandatory conventions.
+Generates complete, production-ready Terraform .tf files for AWS modules. Uses service-specific skills for exact resource definitions and [references/module-conventions.md](references/module-conventions.md) for mandatory patterns.
 
 ## Workflow
 
@@ -39,81 +26,59 @@ Progress:
 
 ### 1. Read Your Service-Specific Skill
 
-Your service-specific skill is NOT loaded into your context automatically.
-You MUST use `ls /skills/` to locate it, and `read_file` to load it. 
+Your service-specific skill is NOT loaded automatically. Use `ls /skills/` to locate it and `read_file` to load it.
 
 It contains:
 - **SKILL.md**: Which files to create, in what order, with which resources
 - **references/**: Detailed HCL patterns, variable schemas, output schemas
 
-Follow the workflow in your service-specific SKILL.md exactly. 
-If no service-specific skill exists (e.g. `ls /skills/` is empty or only contains base skills), fall back to the conventions in
-[references/module-conventions.md](references/module-conventions.md).
+Follow the service-specific SKILL.md workflow exactly. If no service-specific skill exists, fall back to [references/module-conventions.md](references/module-conventions.md).
 
 ### 2. Read Reference Files
 
-Load **only** what you need for the current file you are generating:
+Load **only** what you need for the current file being generated:
 
-- When writing `main.tf`: read `references/resource-patterns.md`
-- When writing `variables.tf`: read `references/variables-schema.md`
-- When writing `outputs.tf`: read `references/outputs-schema.md`
-- When security resources are involved: read `references/security-rules.md`
-- For full execution context: read `references/execution-blueprint.md`
+- `main.tf` → `references/resource-patterns.md`
+- `variables.tf` → `references/variables-schema.md`
+- `outputs.tf` → `references/outputs-schema.md`
+- Security resources → `references/security-rules.md`
+- Full execution context → `references/execution-blueprint.md`
 
-> **Context budget**: Do NOT read all references upfront. Read each one only
-> when you are about to write the corresponding .tf file.
+> **Context budget**: Do NOT read all references upfront. Read each only when writing the corresponding file.
 
 ### 3. Generate All .tf Files
 
-Write EVERY file to `./workspace/terraform_modules/{service}/{filename}`.
+Write every file to `./workspace/terraform_modules/{service}/{filename}`.
 
-Always generate these files (minimum set):
+Minimum file set:
 1. `versions.tf` — Terraform and provider version constraints
 2. `locals.tf` — Feature toggles and computed values
 3. `main.tf` — Primary resource declarations
 4. `variables.tf` — Input variable definitions
 5. `outputs.tf` — Output value definitions
 
-Generate additional files as declared by the service-specific skill (e.g.,
-`iam.tf`, `security_groups.tf`, `data.tf`, `policies.tf`).
+Generate additional files as declared by the service-specific skill (`iam.tf`, `security_groups.tf`, `data.tf`, `policies.tf`).
 
 ### 4. Generate README.md
 
-ALWAYS generate a `README.md` at `./workspace/terraform_modules/{service}/README.md`
-with:
-- Module description and purpose
-- Usage example with `module` block
-- Inputs table (from variables.tf)
-- Outputs table (from outputs.tf)
-- Requirements (Terraform version, provider version)
+Always generate `./workspace/terraform_modules/{service}/README.md` with: module description, usage example with `module` block, inputs table, outputs table, and requirements (Terraform/provider versions).
 
 ### 5. Configure State Backend (if applicable)
 
-If your service-specific SKILL.md dictates a state backend configuration (e.g., in `references/state-management.md`), you MUST create a `backend.tf` file.
-Implement the configuration exactly as specified in the reference file, particularly the `terraform { backend "s3" {} }` block. Do NOT skip this if instructed.
+If the service-specific SKILL.md specifies a state backend (e.g., in `references/state-management.md`), create `backend.tf` with the exact configuration specified.
 
 ### 6. Apply Mandatory Patterns
 
-These patterns are non-negotiable. See
-[references/module-conventions.md](references/module-conventions.md) for details.
+Non-negotiable patterns — see [references/module-conventions.md](references/module-conventions.md) for the full decision table.
 
-**Conditional creation**: Use `count` for singleton (0-or-1) resources, `for_each`
-for multiple keyed instances. Choose based on the resource's cardinality — see
-[references/module-conventions.md](references/module-conventions.md) for the full
-decision table.
+**Conditional creation**: `count` for singleton (0-or-1) resources, `for_each` for keyed instances:
 ```hcl
-# count — single toggle
 resource "aws_{resource}" "this" {
   count = local.create_{resource} ? 1 : 0
 }
-
-# for_each — multiple keyed instances
-resource "aws_{resource}" "this" {
-  for_each = local.{resource}_map
-}
 ```
 
-**Tagging**: Always use the merge pattern.
+**Tagging**: Always merge:
 ```hcl
 tags = merge(
   { "Name" = var.name },
@@ -122,17 +87,16 @@ tags = merge(
 )
 ```
 
-**Safe outputs**: Use `try()` for conditional resources.
+**Safe outputs**: `try()` for conditional resources:
 ```hcl
 output "{service}_id" {
   value = try(aws_{resource}.this[0].id, null)
 }
 ```
 
-**No hardcoded values**: Region, account ID, credentials, and CIDR ranges must
-be variables. Never hardcode these.
+**No hardcoded values**: Region, account ID, credentials, CIDR ranges must be variables.
 
-**Provider locking**: Always lock providers in `versions.tf` with `>=` constraint.
+**Provider locking**: Always use `>=` constraint in `versions.tf`.
 
 ### 7. Return Summary
 
@@ -143,15 +107,9 @@ Generated {N} files: [list]. Key design decisions: [brief summary].
 
 ## Gotchas
 
-- The `execute` tool uses REAL paths (no leading `/`), but `read_file` and
-  `write_file` use VIRTUAL paths (with leading `/`). Never mix them.
-- Variable `description` fields must be non-empty strings — Terraform warns on
-  empty descriptions.
-- Every resource MUST have a `Name` tag. AWS resources without Name tags are
-  invisible in the console.
-- When using `count`, ALWAYS access attributes with `[0]` index:
-  `aws_{resource}.this[0].id`, not `aws_{resource}.this.id`.
-- Use `try()` in outputs to safely handle `count = 0` cases.
-- Never use `for_each` with a computed value that depends on resource
-  attributes — it causes the "value depends on resource attributes that cannot
-  be determined until apply" error.
+- `execute` uses REAL paths (no leading `/`); `read_file`/`write_file` use VIRTUAL paths (with `/`). Never mix them.
+- Every variable must have a non-empty `description`.
+- Every resource must have a `Name` tag.
+- With `count`, access attributes via `[0]` index: `aws_{resource}.this[0].id`.
+- Use `try()` in outputs to handle `count = 0` cases.
+- Never use `for_each` with a value that depends on resource attributes — causes "cannot be determined until apply" errors.

--- a/skills/tf-module-updater/SKILL.md
+++ b/skills/tf-module-updater/SKILL.md
@@ -1,15 +1,7 @@
 ---
 name: tf-module-updater
-description: >
-  Fetches existing Terraform modules from GitHub via MCP tools and applies
-  targeted, surgical edits. Reads module-index.md to locate modules in the
-  repository, uses get_file_contents to fetch current files with SHAs, and
-  applies changes via edit_file without full file rewrites. Use when asked to
-  update, modify, patch, or change an existing Terraform module that is already
-  committed to GitHub. Not for new module creation.
-compatibility: >
-  Requires GitHub MCP server tools (list_directory_contents, get_file_contents,
-  create_or_update_file). Requires read_file, write_file, and edit_file tools.
+description: "Fetches existing Terraform modules from GitHub via MCP tools and applies targeted, surgical edits. Reads module-index.md to locate modules in the repository, uses get_file_contents to fetch current files with SHAs, and applies changes via edit_file without full file rewrites. Use when asked to update, modify, patch, or change an existing Terraform module that is already committed to GitHub. Not for new module creation."
+compatibility: "Requires GitHub MCP server tools (list_directory_contents, get_file_contents, create_or_update_file). Requires read_file, write_file, and edit_file tools."
 metadata:
   author: talkops-ai
   version: "1.0"
@@ -19,12 +11,7 @@ allowed-tools: read_file write_file edit_file ls grep
 
 # Terraform Module Updater
 
-## Overview
-
-You fetch existing Terraform modules from GitHub and apply targeted changes.
-You never rewrite entire files — you make surgical, minimal edits that
-preserve existing formatting and conventions. This is the UPDATE workflow
-counterpart to the tf-generator's CREATE workflow.
+Fetches existing Terraform modules from GitHub and applies surgical edits. Counterpart to the tf-generator's CREATE workflow — this is the UPDATE workflow.
 
 ## Workflow
 
@@ -33,103 +20,100 @@ Progress:
 - [ ] Step 2: Fetch existing module files from GitHub
 - [ ] Step 3: Analyze the existing code structure
 - [ ] Step 4: Apply targeted changes
-- [ ] Step 5: Update documentation
-- [ ] Step 6: Return summary
+- [ ] Step 5: Validate changes
+- [ ] Step 6: Update documentation
+- [ ] Step 7: Return summary
 
 ### 1. Locate the Module
 
-Read the module index to find the module path:
+Read the module index and org conventions:
 
 ```
 read_file /memories/module-index.md
-```
-
-The index contains entries like:
-```
-| Service | Repo Path | Last Updated |
-|---------|-----------|-------------|
-| {service} | modules/{service}/ | 2025-01-15 |
-```
-
-If the module is not in the index, ask the coordinator for the repository path.
-
-Also load organizational conventions:
-```
 read_file /memories/org-standards.md
 ```
 
+The index maps services to repo paths. If the module is not in the index, ask the coordinator for the repository path.
+
 ### 2. Fetch Existing Files from GitHub
 
-Use GitHub MCP tools to fetch all `.tf` files:
+Use GitHub MCP tools to fetch all `.tf` files with their SHAs:
 
-1. List the directory contents:
-   ```
-   list_directory_contents(repo, module_path)
-   ```
+```
+list_directory_contents(repo="{owner}/{repo}", path="{module_path}")
+```
 
-2. For each file, fetch the content AND SHA:
-   ```
-   get_file_contents(repo, file_path)
-   ```
+For each file, fetch content and SHA (needed for commit operations):
 
-3. Write fetched files to the local workspace:
-   ```
-   write_file ./workspace/terraform_modules/{service}/{filename} {content}
-   ```
+```
+get_file_contents(repo="{owner}/{repo}", path="{module_path}/main.tf")
+# Response includes: content, sha, encoding
+```
 
-> **Critical**: Track the SHA of every file you fetch. You will need it when
-> committing changes back to GitHub.
+Write fetched files to workspace:
+
+```
+write_file ./workspace/terraform_modules/{service}/{filename} {content}
+```
+
+Track every SHA — you need them when committing back via `create_or_update_file`.
 
 ### 3. Analyze the Existing Code
 
-Before making changes, understand the current module:
-- Resource naming conventions used
-- Variable naming patterns
-- Tagging strategy
-- Provider version constraints
-- Conditional creation patterns (`count` or `for_each`)
-
-See [references/update-patterns.md](references/update-patterns.md) for common
-analysis patterns.
+Identify the module's conventions before editing. See [references/update-patterns.md](references/update-patterns.md) for detailed patterns. Key signals:
+- Iteration pattern (`count` or `for_each`) — follow whichever the module uses
+- Naming conventions for resources, variables, and toggles
+- Tagging strategy (merge pattern, prefix patterns)
 
 ### 4. Apply Targeted Changes
 
 Use `edit_file` for ALL modifications. Never rewrite an entire file.
 
+**Example — adding a variable to an existing `variables.tf`:**
+
+```
+edit_file(
+  path="./workspace/terraform_modules/{service}/variables.tf",
+  edits=[{
+    old_text='variable "tags" {',
+    new_text='variable "enable_logging" {\n  description = "Whether to enable access logging"\n  type        = bool\n  default     = true\n}\n\nvariable "tags" {'
+  }]
+)
+```
+
 **Rules for surgical edits:**
 - Only touch files that need changing
 - Preserve existing formatting, indentation, and conventions
-- When adding new resources, follow the established naming patterns
-- When adding variables, maintain alphabetical or logical grouping
-- When modifying `count` or `for_each` expressions, verify all dependent
-  references (outputs, other resources, data sources)
-- When changing `for_each` keys, verify that outputs using `values()` or
-  direct key access are still valid
+- Follow the module's established iteration pattern — do not mix `count` and `for_each`
+- When modifying `count` or `for_each`, verify all dependent references (outputs, other resources, data sources)
+- When changing `for_each` keys, verify outputs using `values()` or direct key access
 
-### 5. Update Documentation
+### 5. Validate Changes
 
-If inputs or outputs changed:
-- Update the README.md inputs table
-- Update the README.md outputs table
-- Update any usage examples that reference changed variables
+After applying edits, run validation to catch errors before committing:
 
-### 6. Return Summary
+```
+execute("cd workspace/terraform_modules/{service} && terraform init -input=false -no-color -backend=false && terraform validate -no-color")
+```
+
+If validation fails, review the error, fix the edit, and re-validate. Do not proceed to documentation or commit with failing validation.
+
+### 6. Update Documentation
+
+If inputs or outputs changed, update README.md: inputs table, outputs table, and any usage examples referencing changed variables.
+
+### 7. Return Summary
 
 Return exactly:
 ```
-Updated {N} files: [list]. Changes made: [diff summary].
+Updated {N} files: [list]. Changes made: [diff summary]. Validation: PASSED.
 ```
 
 ## Gotchas
 
-- NEVER rewrite an entire file — make targeted, surgical edits only
+- NEVER rewrite an entire file — surgical edits only
 - ALWAYS track file SHAs for GitHub commit operations
-- If `get_file_contents` returns an error (404), the file doesn't exist —
-  treat it as a new file for the commit operation
-- Changing a variable's type is a BREAKING CHANGE — flag it explicitly
-- Removing a variable or output is a BREAKING CHANGE — flag it explicitly
-- When changing `count` to `for_each` (or vice versa), Terraform will
-  DESTROY and RECREATE all instances **unless** `moved` blocks are added
-  to map each old address to the new one — always recommend `moved` blocks
-- Splat expressions (`[*]`) work with `count` but NOT directly with
-  `for_each` — use `values(resource)[*].attr` instead
+- If `get_file_contents` returns 404, treat as a new file (no SHA needed)
+- Changing a variable's type or removing a variable/output is a BREAKING CHANGE — flag explicitly
+- When switching `count` ↔ `for_each`, add `moved` blocks to prevent destroy/recreate
+- Splat `[*]` works with `count` but not `for_each` — use `values(resource)[*].attr` instead

--- a/skills/tf-module-validator/SKILL.md
+++ b/skills/tf-module-validator/SKILL.md
@@ -1,16 +1,7 @@
 ---
 name: tf-module-validator
-description: >
-  Validates Terraform modules by running terraform init, fmt check, and
-  validate commands in a sandbox environment. Returns VALID or INVALID with
-  structured error details including file names and line numbers. Use after
-  tf-generator or tf-updater writes .tf files to verify correctness before
-  committing to GitHub. Handles path system differences between virtual
-  filesystem and real shell execution.
-compatibility: >
-  Requires execute tool for running shell commands and read_file/ls tools
-  for virtual filesystem access. Requires Terraform CLI >= 1.5 installed
-  in the execution environment.
+description: "Validates Terraform modules by running terraform init, fmt check, and validate commands in a sandbox environment. Returns VALID or INVALID with structured error details including file names and line numbers. Use after tf-generator or tf-updater writes .tf files to verify correctness before committing to GitHub. Handles path system differences between virtual filesystem and real shell execution."
+compatibility: "Requires execute tool for running shell commands and read_file/ls tools for virtual filesystem access. Requires Terraform CLI >= 1.5 installed in the execution environment."
 metadata:
   author: talkops-ai
   version: "1.0"
@@ -20,27 +11,16 @@ allowed-tools: read_file ls execute
 
 # Terraform Module Validator
 
-## Overview
+Validates Terraform modules via `terraform init`, `fmt -check`, and `validate` in a sandbox. Returns structured VALID/INVALID results for the coordinator.
 
-You validate Terraform modules by running the Terraform CLI in a sandbox.
-Your job is to confirm that generated or updated modules are syntactically
-correct, properly formatted, and semantically valid before they are committed
-to GitHub.
+## Path Systems
 
-## ⚠️ PATH WARNING — READ THIS FIRST
-
-The `ls` and `read_file` tools use **VIRTUAL** absolute paths (starting with `/`).
-The `execute` tool runs **REAL** shell commands from the project root directory.
-
-These are **TWO DIFFERENT** path systems:
+`ls`/`read_file` use **VIRTUAL** paths (leading `/`). `execute` uses **REAL** paths (no leading `/`):
 
 ```
-✓ CORRECT execute: execute("cd workspace/terraform_modules/{service} && terraform init -input=false -no-color")
-✗ WRONG execute:   execute("cd /workspace/terraform_modules/{service} && terraform init -input=false -no-color")
+✓ CORRECT: execute("cd workspace/terraform_modules/{service} && terraform init -input=false -no-color")
+✗ WRONG:   execute("cd /workspace/terraform_modules/{service} && terraform init -input=false -no-color")
 ```
-
-The difference: **NO leading slash** in execute paths. The shell cwd is already
-the project root.
 
 ## Workflow
 
@@ -52,8 +32,6 @@ Progress:
 - [ ] Step 5: Return result in strict format
 
 ### 1. Verify Module Directory
-
-First, confirm the module directory exists using virtual paths:
 
 ```
 ls /workspace/terraform_modules/{service}/
@@ -70,12 +48,7 @@ INVALID: module directory not found at workspace/terraform_modules/{service}/
 execute("cd workspace/terraform_modules/{service} && terraform init -input=false -no-color -backend=false")
 ```
 
-Use `-backend=false` to skip backend configuration (not needed for validation).
-Use `-input=false` to prevent interactive prompts.
-Use `-no-color` for clean, parseable output.
-
-If init fails, check [references/common-errors.md](references/common-errors.md)
-for common causes and fixes.
+If init fails, check [references/common-errors.md](references/common-errors.md) for common causes.
 
 ### 3. Run terraform fmt -check
 
@@ -83,8 +56,7 @@ for common causes and fixes.
 execute("cd workspace/terraform_modules/{service} && terraform fmt -check -recursive -no-color")
 ```
 
-If formatting issues are found, report the files that need formatting.
-This is a **non-blocking** check — report it but continue to validate.
+This is a **non-blocking** check — report files needing formatting but continue to validate.
 
 ### 4. Run terraform validate
 
@@ -92,54 +64,40 @@ This is a **non-blocking** check — report it but continue to validate.
 execute("cd workspace/terraform_modules/{service} && terraform validate -no-color")
 ```
 
-Parse the output for errors. Each error typically includes:
-- File name
-- Line number
-- Error message
-- Affected resource or variable
+Parse errors for file name, line number, error message, and affected resource/variable.
 
 ### 5. Return Result — STRICT FORMAT
 
-The coordinator depends on this exact output format. Return ONLY one of:
+The coordinator parses this output programmatically. Return ONLY one of:
 
-**On success:**
+**Success:**
 ```
 VALID: all checks passed (init ✓, fmt ✓, validate ✓)
 ```
 
-**On success with format warnings:**
+**Success with format warnings:**
 ```
 VALID: all checks passed (init ✓, fmt ⚠ [files need formatting], validate ✓)
 ```
 
-**On failure:**
+**Failure:**
 ```
 INVALID: [structured error list]
   - {file}:{line}: {error_message}
   - {file}:{line}: {error_message}
 ```
 
-Never return anything else. The coordinator parses this output programmatically.
-
 ## Failure Guard
 
-If an `execute` command fails with "No such file or directory" **THREE times**,
-STOP immediately and return:
+If `execute` fails with "No such file or directory" **three times**, STOP:
 
 ```
 INVALID: module directory not found at workspace/terraform_modules/{service}/ after 3 attempts
 ```
 
-Do NOT keep retrying — the path is wrong. Report the error and stop.
-
 ## Gotchas
 
-- Always use `-no-color` flag — color codes break output parsing
-- Always use `-input=false` — interactive prompts hang the execution
-- Always use `-backend=false` for init — backend config is not available in
-  the sandbox
-- If `terraform init` fails with "provider not found," check that
-  `versions.tf` has the correct `source` field (e.g., `hashicorp/aws`)
-- If `terraform validate` reports "Unsupported argument," check for
-  deprecated attributes — see [references/common-errors.md](references/common-errors.md)
-- Remember: `execute` paths have NO leading slash, `read_file` paths DO
+- Always use flags: `-no-color -input=false -backend=false` (color breaks parsing, prompts hang, backend unavailable in sandbox)
+- "Provider not found" on init → check `versions.tf` has correct `source` (e.g., `hashicorp/aws`)
+- "Unsupported argument" on validate → deprecated attributes. See [references/common-errors.md](references/common-errors.md)
+- `execute` paths: NO leading slash. `read_file` paths: leading slash required

--- a/skills/update-planner/SKILL.md
+++ b/skills/update-planner/SKILL.md
@@ -1,16 +1,7 @@
 ---
 name: update-planner
-description: >
-  Analyses existing Terraform modules on GitHub to plan targeted modifications.
-  Fetches current module structure, understands resource naming and variable
-  conventions, identifies dependencies, and produces a structured update plan
-  with impact assessment and breaking change detection. Use when asked to
-  analyse, plan, or prepare changes to an existing Terraform module before
-  applying them. Does NOT modify files — only reads and produces a plan for
-  the tf-updater to execute.
-compatibility: >
-  Requires GitHub MCP server tools (list_directory_contents, get_file_contents)
-  for fetching module files from the repository. Read-only operation.
+description: "Analyses existing Terraform modules on GitHub to plan targeted modifications. Fetches current module structure, understands resource naming and variable conventions, identifies dependencies, and produces a structured update plan with impact assessment and breaking change detection. Use when asked to analyse, plan, or prepare changes to an existing Terraform module before applying them. Does NOT modify files — only reads and produces a plan for the tf-updater to execute."
+compatibility: "Requires GitHub MCP server tools (list_directory_contents, get_file_contents) for fetching module files from the repository. Read-only operation."
 metadata:
   author: talkops-ai
   version: "1.0"
@@ -20,12 +11,7 @@ allowed-tools: read_file ls
 
 # Terraform Update Planner
 
-## Overview
-
-You analyse existing Terraform modules to plan targeted modifications. You
-fetch the current module from GitHub, understand its structure and conventions,
-and produce a structured update plan that the tf-updater will execute. You
-NEVER modify files yourself — you only read and plan.
+Analyses existing Terraform modules to plan targeted modifications. Read-only — produces a structured plan for the tf-updater to execute.
 
 ## Workflow
 
@@ -34,98 +20,96 @@ Progress:
 - [ ] Step 2: Analyse the existing code structure
 - [ ] Step 3: Map the requested change to specific file modifications
 - [ ] Step 4: Assess impact and detect breaking changes
-- [ ] Step 5: Produce the structured update plan
+- [ ] Step 5: Validate plan consistency
+- [ ] Step 6: Produce the structured update plan
 
 ### 1. Fetch the Current Module
 
 Use GitHub MCP tools to fetch the module structure:
 
-1. List all files in the module directory:
-   ```
-   list_directory_contents(repo, module_path)
-   ```
+```
+list_directory_contents(repo, module_path)
+```
 
-2. Fetch key files for analysis:
-   ```
-   get_file_contents(repo, "{module_path}/main.tf")
-   get_file_contents(repo, "{module_path}/variables.tf")
-   get_file_contents(repo, "{module_path}/outputs.tf")
-   get_file_contents(repo, "{module_path}/versions.tf")
-   ```
+Fetch the core files — `main.tf`, `variables.tf`, `outputs.tf`, `versions.tf` — plus any files relevant to the requested change (`locals.tf` for feature toggles, `iam.tf` for IAM changes, `security_groups.tf` for network changes):
 
-3. Optionally fetch additional files if the change may affect them:
-   - `locals.tf` — if feature toggles are involved
-   - `iam.tf` — if IAM changes are requested
-   - `security_groups.tf` — if network changes are requested
+```
+get_file_contents(repo, "{module_path}/main.tf")
+get_file_contents(repo, "{module_path}/variables.tf")
+get_file_contents(repo, "{module_path}/outputs.tf")
+get_file_contents(repo, "{module_path}/versions.tf")
+```
+
+If `get_file_contents` returns a 404, note the file as absent — do not fail. If the module path itself does not exist, STOP and report:
+```
+Cannot plan: module not found at {module_path}. Verify the path with the coordinator.
+```
 
 ### 2. Analyse the Existing Code
 
-Understand the current module by examining:
+Identify the module's conventions by examining:
 
-**Resource structure:**
-- What resources are defined and how they're named
-- Which resources use `count` vs. `for_each`
-- Dependency chains (`depends_on`, implicit references)
+- **Iteration pattern**: `count` vs `for_each` — the plan must follow whichever the module uses
+- **Naming conventions**: resource names, variable prefixes (`create_*`, `enable_*`)
+- **Dependency chains**: `depends_on`, implicit references across files
+- **Output safety**: whether `try()` is used for conditional resources
 
-**Variable patterns:**
-- Naming convention (snake_case, prefix patterns)
-- Type constraints used
-- Default values and validation rules
-- Boolean toggles (`create_*`, `enable_*`)
-
-**Output patterns:**
-- Which attributes are exposed
-- Whether `try()` is used for conditional resources
-- Sensitive outputs
-
-**Provider constraints:**
-- Required Terraform version
-- Required provider version
-- Backend configuration (if any)
+Example analysis output for a VPC module:
+```
+Pattern: count-based iteration (all resources use count with local.create_*)
+Naming: snake_case, resources named "this", toggles use "create_" prefix
+Dependencies: subnets → vpc, route_tables → subnets, nat_gateway → eip
+Outputs: all use try() with [0] index for count safety
+Provider: aws >= 5.40.0, Terraform >= 1.5
+```
 
 ### 3. Map Changes to Files
 
 For each requested change, determine:
 
-1. **Which files need modification** — list specific files
-2. **What specific changes are needed** in each file:
-   - Add resource: main.tf (resource block), variables.tf (new vars), outputs.tf (new outputs), locals.tf (toggle)
+1. **Which files need modification** — list specific files and line ranges
+2. **What specific changes are needed** — concrete additions, modifications, or removals:
+   - Add resource: `main.tf` + `variables.tf` + `outputs.tf` + `locals.tf` (toggle)
    - Modify resource: only the affected file(s)
-   - Remove resource: main.tf, outputs.tf, possibly variables.tf
-3. **Dependency impacts** — what other resources reference the changed ones
+   - Remove resource: `main.tf` + `outputs.tf` + possibly `variables.tf`
+3. **Cross-file dependencies** — trace every reference to the changed resource/variable across all files
 
 ### 4. Assess Impact
 
-Evaluate each change for:
+Evaluate each change using the risk levels and breaking change criteria in [references/analysis-template.md](references/analysis-template.md):
 
-- **Breaking changes**: See [references/analysis-template.md](references/analysis-template.md)
-- **State impact**: Will Terraform need to destroy/recreate resources?
-- **Security impact**: Does the change affect IAM, encryption, or network security?
-- **Cost impact**: Does the change add or remove billable resources?
+- **Breaking changes**: variable removal, type changes, resource renames, `count` ↔ `for_each` switches
+- **State impact**: will Terraform destroy/recreate resources? Include `moved` block guidance if so
+- **Security impact**: changes to IAM, encryption, or network security
+- **Cost impact**: added or removed billable resources
 
-### 5. Produce the Update Plan
+### 5. Validate Plan Consistency
 
-Return a structured plan using this exact format:
+Before producing the final plan, verify:
+- Every new variable referenced in `main.tf` changes has a corresponding entry in `variables.tf` changes
+- Every new resource has corresponding output entries
+- Cross-file references are valid (no dangling references to removed resources)
+- The iteration pattern is consistent with the existing module
+
+### 6. Produce the Update Plan
+
+Return a structured plan following the format in [references/analysis-template.md](references/analysis-template.md). At minimum:
 
 ```
 Update Plan:
-  Target: {module_path}
-  Files to modify: [list]
+  Target: {owner}/{repo} → {module_path}
+  Files to modify: [list with line ranges]
   Changes:
-    - {file}: {description of change}
-    - {file}: {description of change}
-  Breaking changes: [none | list with descriptions]
+    - {file}:{line}: {description of change}
+  Breaking changes: [none | list with impact descriptions]
   Dependencies: [affected downstream resources]
-  Risk assessment: [low | medium | high] — {reason}
+  State impact: [resources that will be created/modified/destroyed]
+  Risk assessment: [low | medium | high] — {justification}
 ```
 
 ## Gotchas
 
-- NEVER modify files yourself — only produce the analysis and plan
-- Be specific about line-level changes when possible
-- Always flag changes that could break existing infrastructure
-- Check for variable dependencies ACROSS files — a variable used in main.tf
-  may also be referenced in locals.tf and outputs.tf
+- NEVER modify files — only read and produce the plan
+- Check variable dependencies ACROSS files — a variable in `main.tf` may also appear in `locals.tf` and `outputs.tf`
 - When a resource is renamed, check ALL outputs and cross-references
-- When removing a variable, check if it has a default — if not, ALL callers
-  will break
+- When removing a variable without a default, ALL callers will break — always flag this


### PR DESCRIPTION
Hey 👋 @structbinary

A multi-agent framework that researches, generates, validates, and commits production-ready Terraform modules through conversation. That's an ambitious pipeline. The 6 specialised skills (generator, validator, updater, committer) show a well-decomposed agent architecture.

I ran your skills through `tessl skill review` at work and found some targeted improvements. Here's the full before/after:

<img width="1312" height="986" alt="score_card" src="https://github.com/user-attachments/assets/c31db869-82b1-46c7-8e4e-376a6d32e85b" />


<details>
<summary>Changes made</summary>

**All 5 skills:**
- Converted frontmatter `description` and `compatibility` fields from YAML folded block scalar (`>`) to standard quoted strings for better tooling compatibility
- Deduplicated guidance that appeared in both workflow steps and Gotchas sections
- Removed explanations of concepts the agent already knows (e.g., what CLI flags do, what HITL stands for)

**tf-module-updater (+11%):**
- Added concrete `edit_file` example with `old_text`/`new_text` pattern showing a real surgical edit
- Added validation checkpoint (Step 5: `terraform validate`) after applying edits — closes a gap where edits could be committed without verification
- Replaced pseudocode-style tool calls with specific MCP tool syntax including parameter names

**update-planner (+8%):**
- Added validation checkpoint (Step 5) to verify cross-file reference consistency before producing the plan
- Added concrete example analysis output for a VPC module so the agent has a clear reference pattern
- Added error recovery for missing modules (404 handling, stop condition)
- Tightened inline analysis checklist to focus on signals that affect the plan

**github-committer (+6%):**
- Consolidated new-vs-existing file guidance into compact format
- Reduced Gotchas from 7 items to 4 by merging duplicates

**tf-module-generator (+6%):**
- Reduced redundant references to `module-conventions.md` (appeared 3 times, now 2)
- Tightened mandatory patterns section prose

**tf-module-validator (+6%):**
- Consolidated path warning into compact section with correct/wrong example
- Merged 6 CLI flag gotchas into a single line

</details>

Honest disclosure. I work at https://github.com/tesslio where we build tooling around skills like these. Not a pitch - just saw room for improvement and wanted to contribute.

I also added a lightweight GitHub Action that auto-reviews any skill.md changed in a PR (includes min permissions, uses a pinned action version, only posts a review comment).

This means that it gives you and your contributors an instant quality signal before you have to review yourself (no signup, no tokens needed).

Want to self-improve your skills? Just point your agent (Claude Code, Codex, etc.) at this Tessl guide (https://docs.tessl.io/evaluate/optimize-a-skill-using-best-practices) and ask it to optimize your skill. Ping me - @yogesh-tessl (https://github.com/yogesh-tessl) - if you hit any snags.

Thanks in advance 🙏